### PR TITLE
Launch SMART on FHIR app from Request Generator

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,13 +15,13 @@ interface App {
 }
 
 const smartLaunch = () => {
-
   FHIR.oauth2
     .init({
-      clientId: '20560ea5-f224-4658-b667-4e6bab935c85',
-      scope: 'launch/patient openid profile'
+      clientId: 'app-login',
+      scope: 'launch openid profile user/Patient.read patient/Patient.read user/Practitioner.read'
     })
     .then(client => {
+      console.log(client);
       root.render(
         <React.StrictMode>
           <App client={client} />

--- a/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
+++ b/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
@@ -135,8 +135,21 @@ function MedReqDropDown(props: any) {
 
 
     useEffect(() => {
-        if (patient && patient.id && client.user.id && selectedMedicationCardBundle) {
-            const hook = new OrderSign(patient.id, client.user.id, { resourceType: 'Bundle', type: 'batch', entry: [selectedMedicationCardBundle] });
+        // get the userId from the client if possible, otherwise pull it from the appContext
+        let userId = client.user.id;
+        if (!userId) {
+            const appContextString = client.state?.tokenResponse?.appContext;
+            console.log('appContext: ' + appContextString);
+            const appContext: { [key: string]: string } = {};
+            appContextString.split('&').map((e: string)=>{
+                const temp: string[] = e.split('=');
+                appContext[temp[0]] = temp[1];
+            });
+            userId = appContext?.user;
+        }
+
+        if (patient && patient.id && userId && selectedMedicationCardBundle) {
+            const hook = new OrderSign(patient.id, userId, { resourceType: 'Bundle', type: 'batch', entry: [selectedMedicationCardBundle] });
             const tempHook = hook.generate();
 
             hydrate(getFhirResource, example.prefetch, tempHook).then(() => {


### PR DESCRIPTION
Update scope and clientId to be launchable from the request-generator.
Pull user from appContext if not in token_id (client).