### PR TITLE
launch dtr naturally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import CloseIcon from '@mui/icons-material/CloseOutlined';
 import { ReactElement, useCallback, useEffect, useState, MouseEvent } from 'react';
 import { MemoizedTabPanel } from './TabDisplay';
 import { IconButton } from '@mui/material';
+import { SmartApp } from './views/Questionnaire/SmartApp';
+import { getAppContext } from './views/Questionnaire/questionnaireUtil';
 
 function tabProps(index: number) {
   return {
@@ -37,13 +39,30 @@ function App(props: AppProps) {
   };
   useEffect(() => {
     const homeName = 'Home';
-    setTabs([
-      {
-        element: <Patient client={client} tabCallback={addTab} />,
-        name: homeName,
-        closeable: false
-      }
-    ]);
+    if(client.state.tokenResponse?.appContext) {
+      const appContext = getAppContext(client.state.tokenResponse?.appContext);
+      // launched with an app context already available
+      const smartApp = <SmartApp
+      smartClient={props.client}
+      standalone={false}
+      appContext={appContext}
+      patientId={client.getPatientId() || ''} />;
+      setTabs([
+        {
+          element: smartApp,
+          name: homeName,
+          closeable: false
+        }
+      ]);
+    } else {
+      setTabs([
+        {
+          element: <Patient client={client} tabCallback={addTab} />,
+          name: homeName,
+          closeable: false
+        }
+      ]);
+    }
     setValue(homeName);
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { ReactElement, useCallback, useEffect, useState, MouseEvent } from 'reac
 import { MemoizedTabPanel } from './TabDisplay';
 import { IconButton } from '@mui/material';
 import { SmartApp } from './views/Questionnaire/SmartApp';
-import { getAppContext } from './views/Questionnaire/questionnaireUtil';
+import { AppContext, getAppContext } from './views/Questionnaire/questionnaireUtil';
 
 function tabProps(index: number) {
   return {
@@ -30,6 +30,7 @@ function App(props: AppProps) {
   const client = props.client;
   const [value, setValue] = useState('');
   const [tabs, setTabs] = useState<SmartTab[]>([]);
+  const [staticContent, setStaticContent] = useState<ReactElement>();
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(tabs[newValue].name);
   };
@@ -39,21 +40,21 @@ function App(props: AppProps) {
   };
   useEffect(() => {
     const homeName = 'Home';
-    if(client.state.tokenResponse?.appContext) {
-      const appContext = getAppContext(client.state.tokenResponse?.appContext);
+    let appContext: AppContext | null = null;
+    if (client.state.tokenResponse?.appContext) {
+      appContext = getAppContext(client.state.tokenResponse?.appContext);
       // launched with an app context already available
-      const smartApp = <SmartApp
-      smartClient={props.client}
-      standalone={false}
-      appContext={appContext}
-      patientId={client.getPatientId() || ''} />;
-      setTabs([
-        {
-          element: smartApp,
-          name: homeName,
-          closeable: false
-        }
-      ]);
+    }
+    if (appContext && (appContext.questionnaire || appContext.response)) {
+      const smartApp = (
+        <SmartApp
+          smartClient={props.client}
+          standalone={false}
+          appContext={appContext}
+          patientId={client.getPatientId() || ''}
+        />
+      );
+      setStaticContent(smartApp);
     } else {
       setTabs([
         {
@@ -85,70 +86,76 @@ function App(props: AppProps) {
 
   return (
     <Box className="main">
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          position: 'fixed',
-          zIndex: '100',
-          width: '100%',
-          bgcolor: 'background.paper'
-        }}
-      >
-        <Tabs
-          orientation="horizontal"
-          variant="scrollable"
-          value={tabs.findIndex(tab => {
-            return tab.name === value;
-          })}
-          onChange={handleChange}
-          aria-label="tabs"
-        >
-          {tabs.map((tab, i) => {
-            return (
-              <Tab
-                label={
-                  typeof tab.name === 'string' ? (
-                    <span>
-                      {' '}
-                      {tab.name}
-                      {tab.closeable && (
-                        <IconButton
-                          component="div"
-                          onClick={event => handleClose(event, tab)}
-                          style={{ padding: '0px 5px 0px 5px' }}
-                        >
-                          <CloseIcon fontSize="small" />
-                        </IconButton>
-                      )}
-                    </span>
-                  ) : (
-                    tab.name
-                  )
-                }
-                {...tabProps(i)}
-                key={i}
-              />
-            );
-          })}
-        </Tabs>
-      </Box>
-      <div style={{ paddingTop: '48px' }}>
-        {tabs.map((tab, i) => {
-          return (
-            <MemoizedTabPanel
+      {staticContent ? (
+        staticContent
+      ) : (
+        <div>
+          <Box
+            sx={{
+              borderBottom: 1,
+              borderColor: 'divider',
+              position: 'fixed',
+              zIndex: '100',
+              width: '100%',
+              bgcolor: 'background.paper'
+            }}
+          >
+            <Tabs
+              orientation="horizontal"
+              variant="scrollable"
               value={tabs.findIndex(tab => {
                 return tab.name === value;
               })}
-              index={i}
-              key={i}
-              name={tab.name}
+              onChange={handleChange}
+              aria-label="tabs"
             >
-              {tab.element}
-            </MemoizedTabPanel>
-          );
-        })}
-      </div>
+              {tabs.map((tab, i) => {
+                return (
+                  <Tab
+                    label={
+                      typeof tab.name === 'string' ? (
+                        <span>
+                          {' '}
+                          {tab.name}
+                          {tab.closeable && (
+                            <IconButton
+                              component="div"
+                              onClick={event => handleClose(event, tab)}
+                              style={{ padding: '0px 5px 0px 5px' }}
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          )}
+                        </span>
+                      ) : (
+                        tab.name
+                      )
+                    }
+                    {...tabProps(i)}
+                    key={i}
+                  />
+                );
+              })}
+            </Tabs>
+          </Box>
+          <div style={{ paddingTop: '48px' }}>
+            {tabs.map((tab, i) => {
+              return (
+                <MemoizedTabPanel
+                  value={tabs.findIndex(tab => {
+                    return tab.name === value;
+                  })}
+                  index={i}
+                  key={i}
+                  name={tab.name}
+                >
+                  {tab.element}
+                </MemoizedTabPanel>
+              );
+            })}
+          </div>
+        </div>
+      )}
       {/* <div className='App'>
         <Container className='NavContainer' maxWidth='xl'>
           <div className='containerg'>

--- a/src/views/Patient/MedReqDropDown/cdsHooksCards/cdsHooksCard.tsx
+++ b/src/views/Patient/MedReqDropDown/cdsHooksCards/cdsHooksCard.tsx
@@ -6,7 +6,7 @@ import Client from 'fhirclient/lib/Client';
 
 import { Card as HooksCard, Link } from '../../../../cds-hooks/resources/HookTypes';
 import { SmartApp } from '../../../Questionnaire/SmartApp';
-import { AppContext } from '../../../Questionnaire/questionnaireUtil';
+import { AppContext, getAppContext } from '../../../Questionnaire/questionnaireUtil';
 
 // TODO:
 //  - create a css file for better style
@@ -104,28 +104,9 @@ const CdsHooksCard = (props: CdsHooksCardProps) => {
     } else if (link.type === 'smart') {
       console.log('    launch: ' + link.url.split('?')[0]);
       console.log(link);
-      const appContext: AppContext = {};
+      let appContext: AppContext = {};
       if (link.appContext) {
-        try {
-          // Fix + encoded spaces back to precent encoded spaces
-          const encodedAppString = link.appContext.replace(/\+/g, '%20');
-          const appString = decodeURIComponent(encodedAppString);
-          // Could switch to this later
-          appString.split('&').map(e => {
-            const temp = e.split('=');
-            if (
-              temp[0] === 'questionnaire' ||
-              temp[0] === 'order' ||
-              temp[0] === 'coverage' ||
-              temp[0] === 'response'
-            ) {
-              appContext[temp[0]] = temp[1];
-            }
-          });
-        } catch (e) {
-          console.log('failed to get appContext');
-          throw e;
-        }
+        appContext = getAppContext(link.appContext);
       }
       props.tabCallback(
         <SmartApp

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -69,6 +69,7 @@ interface QuestionnaireProps {
   setPriorAuthClaim: (n: Bundle) => void;
   setSpecialtyRxBundle: (n: Bundle) => void;
   setRemsAdminResponse: (n: any) => void;
+  setFormElement: (n: HTMLElement) => void;
 }
 
 interface GTableResult {
@@ -156,7 +157,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       if (
         props.filterChecked &&
         event.target instanceof Element &&
-        event.target?.id != 'filterCheckbox' &&
+        event.target?.id != `filterCheckbox-${props.qform.id}` &&
         event.target.id != 'attestationCheckbox'
       ) {
         const checkIfFilter = (
@@ -224,33 +225,37 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
 
     console.log(lform);
 
-    LForms.Util.addFormToPage(lform, 'formContainer');
-    const header = document.getElementsByClassName('lf-form-title')[0];
-    const el = document.createElement('div');
-    el.setAttribute('id', 'button-container');
-    header.appendChild(el);
-    props.renderButtons(el);
+    LForms.Util.addFormToPage(lform, `formContainer-${props.qform.id}`);
+    const specificForm = document.getElementById(`formContainer-${props.qform.id}`);
+    if (specificForm) {
+      const header = specificForm.getElementsByClassName('lf-form-title')[0];
+      const el = document.createElement('div');
+      el.setAttribute('id', `button-container-${props.qform.id}`);
+      header.appendChild(el);
+      props.renderButtons(el);
 
-    const patientInfoEl = document.createElement('div');
-    patientInfoEl.setAttribute('id', 'patientInfo-container');
-    header.appendChild(patientInfoEl);
-    const patientId = getPatient().replace('Patient/', '');
-    const patientInfoElement = (display: string) => (
-      <div className="patient-info-panel">
-        <label>Patient: {display}</label>
-      </div>
-    );
-    props.smartClient.request('Patient/' + patientId).then(
-      result => {
-        const root = createRoot(patientInfoEl);
-        root.render(patientInfoElement(`${result.name[0].given[0]} ${result.name[0].family}`));
-      },
-      error => {
-        console.log('Failed to retrieve the patient information. Error is ', error);
-        const root = createRoot(patientInfoEl);
-        root.render(patientInfoElement('Unknown'));
-      }
-    );
+      const patientInfoEl = document.createElement('div');
+      patientInfoEl.setAttribute('id', 'patientInfo-container');
+      header.appendChild(patientInfoEl);
+      const patientId = getPatient().replace('Patient/', '');
+      const patientInfoElement = (display: string) => (
+        <div className="patient-info-panel">
+          <label>Patient: {display}</label>
+        </div>
+      );
+      props.smartClient.request('Patient/' + patientId).then(
+        result => {
+          const root = createRoot(patientInfoEl);
+          root.render(patientInfoElement(`${result.name[0].given[0]} ${result.name[0].family}`));
+        },
+        error => {
+          console.log('Failed to retrieve the patient information. Error is ', error);
+          const root = createRoot(patientInfoEl);
+          root.render(patientInfoElement('Unknown'));
+        }
+      );
+      props.setFormElement(specificForm);
+    }
 
     props.filterFieldsFn(true);
   };
@@ -915,7 +920,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     const currentQuestionnaireResponse = window.LForms.Util.getFormFHIRData(
       'QuestionnaireResponse',
       props.fhirVersion.toUpperCase(),
-      '#formContainer'
+      `#formContainer-${props.qform.id}`
     );
     //const mergedResponse = this.mergeResponseForSameLinkId(currentQuestionnaireResponse);
     retrieveQuestions(url, buildNextQuestionRequest(props.qform, currentQuestionnaireResponse))
@@ -1140,7 +1145,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     const qr: QuestionnaireResponseSmart = window.LForms.Util.getFormFHIRData(
       'QuestionnaireResponse',
       props.fhirVersion.toUpperCase(),
-      '#formContainer'
+      `#formContainer-${props.qform.id}`
     );
     //console.log(qr);
     qr.status = status;
@@ -1600,7 +1605,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
   const showPopup = !isAdaptive || isAdaptiveFormWithoutItem();
   return (
     <div>
-      <div id="formContainer"></div>
+      <div id={`formContainer-${props.qform.id}`}></div>
       {!isAdaptive && props.formFilled ? (
         <div className="form-message-panel">
           <p>

--- a/src/views/Questionnaire/questionnaireUtil.ts
+++ b/src/views/Questionnaire/questionnaireUtil.ts
@@ -18,6 +18,25 @@ export interface AppContext {
   coverage?: string;
 }
 // to get FHIR properties of the form answer{whatever}
+export function getAppContext(appContextString: string) {
+  const appContext: AppContext = {};
+  // Fix + encoded spaces back to precent encoded spaces
+  const encodedAppString = appContextString.replace(/\+/g, '%20');
+  const appString = decodeURIComponent(encodedAppString);
+  // Could switch to this later
+  appString.split('&').map(e => {
+    const temp = e.split('=');
+    if (
+      temp[0] === 'questionnaire' ||
+      temp[0] === 'order' ||
+      temp[0] === 'coverage' ||
+      temp[0] === 'response'
+    ) {
+      appContext[temp[0]] = temp[1];
+    }
+  });
+  return appContext;
+}
 export function findValueByPrefix(object: MyObject, prefix: string) {
   for (const property in object) {
     if (object.hasOwnProperty(property) && property.toString().startsWith(prefix)) {


### PR DESCRIPTION
This PR adds the functionality to launch DTR the same way as it was originally launched, from the request generator with a patient and app context already retrieved.  The code from DTR handling this actually ended up being unnecessary, since the SMART client library takes care of login and maintains the app context in its state when getting the access token.  This means we can just pass the app context along without needing to do DTR's more direct and granular approach.

This does mean we lose some control over the launch of the SMART app.  By letting the SMART client library handle it, we're limited by the library.  

You can test this PR by opening the request generator and attempting to launch the smart app through a typical workflow.  Pick a patient and a medication request, send it to the REMS admin, and click on a smart link in the returned card.

Note that the REMS admin is currently configured to point to localhost:3005 for DTR.  You may have to change it to localhost:4040 to get it to work correctly.  

When the app launches it should load the questionnaire form directly just like original DTR does.