### PR TITLE
Liquid layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,18 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
-    integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS" crossorigin="anonymous" />
-  <link href="https://clinicaltables.nlm.nih.gov/lforms-versions/29.0.3/styles/lforms.min.css" media="screen"
-    rel="stylesheet" />
-    <script src='https://kit.fontawesome.com/a076d05399.js'></script>
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css"
+      integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://clinicaltables.nlm.nih.gov/lforms-versions/29.0.3/styles/lforms.min.css"
+      media="screen"
+      rel="stylesheet"
+    />
+    <script src="https://kit.fontawesome.com/a076d05399.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui/dist/semantic.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -36,12 +40,16 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-    crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
-    crossorigin="anonymous"></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+      crossorigin="anonymous"
+    ></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <script src="https://clinicaltables.nlm.nih.gov/lforms-versions/29.3.1/lforms.min.js"></script>
     <script src="https://clinicaltables.nlm.nih.gov/lforms-versions/29.3.1/fhir/lformsFHIRAll.min.js"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -166,16 +166,6 @@ function App(props: AppProps) {
           </div>
         </div>
       )}
-      {/* <div className='App'>
-        <Container className='NavContainer' maxWidth='xl'>
-          <div className='containerg'>
-            <div className='logo'>
-              <ContentPasteIcon sx={{ color: 'white', fontSize: 50, paddingTop: .5, paddingRight: 2.5 }} />
-              <h1>REMS SMART on FHIR App</h1>
-            </div>
-          </div>
-        </Container>
-      </div> */}
     </Box>
   );
 }

--- a/src/TabDisplay.tsx
+++ b/src/TabDisplay.tsx
@@ -20,7 +20,7 @@ function TabPanel(props: TabPanelProps) {
       key={name}
       {...other}
     >
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ p: { xs: 0, sm: 3 } }}>
         <div>{children}</div>
       </Box>
     </div>

--- a/src/views/Patient/MedReqDropDown/MedReqDropDown.css
+++ b/src/views/Patient/MedReqDropDown/MedReqDropDown.css
@@ -4,10 +4,6 @@
   font-size: 14px;
 }
 
-.etasuButton {
-  width: 50%;
-}
-
 .etasuButtonTimestamp {
   max-width: 50%;
   margin: 0 auto;

--- a/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
+++ b/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
@@ -329,10 +329,15 @@ function MedReqDropDown({
                     label={label}
                     value={selectedOption}
                     onChange={handleOptionSelect}
+                    sx={{ '& #dropdown': { textWrap: 'wrap' } }}
                   >
                     {medication ? (
                       medication.data.map(medications => (
-                        <MenuItem key={medications.id} value={medications.id}>
+                        <MenuItem
+                          key={medications.id}
+                          value={medications.id}
+                          sx={{ textWrap: 'wrap' }}
+                        >
                           {getDrugCodeFromMedicationRequest(medications)?.display}
                         </MenuItem>
                       ))
@@ -388,13 +393,8 @@ function MedReqDropDown({
 
                   <Grid item container justifyContent="center" textAlign="center" spacing={2}>
                     {etasu_status_enabled && (
-                      <Grid item sm={4} md={4} lg={4}>
-                        <Button
-                          className="etasuButton"
-                          sx={etasuSx}
-                          variant="contained"
-                          onClick={handleOpenCheckETASU}
-                        >
+                      <Grid item xs={12} sm={6}>
+                        <Button sx={etasuSx} variant="contained" onClick={handleOpenCheckETASU}>
                           <div>
                             <ListIcon fontSize="large" />
                             <p className="etasuButtonText">ETASU: </p>
@@ -405,16 +405,11 @@ function MedReqDropDown({
                       </Grid>
                     )}
                     {pharmacy_status_enabled && (
-                      <Grid item sm={4} md={4} lg={4}>
-                        <Button
-                          className="etasuButton"
-                          sx={pharmSx}
-                          variant="contained"
-                          onClick={handleOpenCheckPharmacy}
-                        >
+                      <Grid item xs={12} sm={6}>
+                        <Button sx={pharmSx} variant="contained" onClick={handleOpenCheckPharmacy}>
                           <div>
                             <LocalPharmacyIcon fontSize="large" />
-                            <p className="etasuButtonText">Medication: </p>
+                            <p className="etasuButtonText">Medication:</p>
                             <p>{getMedicationStatus(pStatus)}</p>
                           </div>
                         </Button>

--- a/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
+++ b/src/views/Patient/MedReqDropDown/MedReqDropDown.tsx
@@ -45,8 +45,6 @@ import EtasuStatus from './etasuStatus/EtasuStatus';
 // Adding in Pharmacy
 import PharmacyStatus from './pharmacyStatus/PharmacyStatus';
 import axios from 'axios';
-import MetRequirements from './etasuStatus/MetRequirements';
-import RemsMetEtasuResponse from './etasuStatus/RemsMetEtasuResponse';
 
 interface MedReqDropDownProps {
   client: Client;

--- a/src/views/Patient/MedReqDropDown/etasuStatus/__test__/EtasuStatus.test.tsx
+++ b/src/views/Patient/MedReqDropDown/etasuStatus/__test__/EtasuStatus.test.tsx
@@ -133,9 +133,7 @@ describe('Test the EtasuStatus Component', () => {
       );
 
       // verify that the values are updated from the call to get the ETASU
-      expect(
-        await screen.findByText('Status: ' + etasu.parameter[0].resource.status)
-      ).toBeInTheDocument();
+      expect(await screen.findByText(/status: pending/i)).toBeInTheDocument();
       expect(await screen.findAllByTestId('etasu-item')).toHaveLength(3);
     }
   });

--- a/src/views/Patient/PatientView.tsx
+++ b/src/views/Patient/PatientView.tsx
@@ -196,7 +196,7 @@ function PatientView(props: PatientViewProps) {
           <TableCell component="th" scope="row" variant="head">
             <span style={{ fontWeight: 'bold' }}>{header}</span>
           </TableCell>
-          <TableCell sx={{ whiteSpace: 'pre' }} variant="body">
+          <TableCell sx={{ whiteSpace: 'pre-wrap' }} variant="body">
             {data}
           </TableCell>
         </TableRow>

--- a/src/views/Patient/PatientView.tsx
+++ b/src/views/Patient/PatientView.tsx
@@ -12,7 +12,7 @@ import {
   Typography
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import { MedicationRequest, Patient } from 'fhir/r4';
+import { Medication, MedicationRequest, Patient, Resource } from 'fhir/r4';
 import Client from 'fhirclient/lib/Client';
 import { ReactElement, useEffect, useState } from 'react';
 import MedReqDropDown from './MedReqDropDown/MedReqDropDown';
@@ -33,7 +33,7 @@ export interface MedicationBundle {
 
   // This is a json object with the key of each element matching the
   // contained FHIR resource
-  references: any;
+  references: { [key: string]: Medication };
 }
 
 //CDS-Hook Request to REMS-Admin for cards
@@ -58,11 +58,9 @@ export const submitToREMS = (
 };
 
 function PatientView(props: PatientViewProps) {
-  function getFhirResource(token: string) {
+  async function getFhirResource(token: string) {
     console.log('getFhirResource: ' + token);
-    return client.request(token).then((e: any) => {
-      return e;
-    });
+    return client.request(token).then((resource: Resource) => resource);
   }
 
   const client = props.client;

--- a/src/views/Questionnaire/QuestionnaireForm.css
+++ b/src/views/Questionnaire/QuestionnaireForm.css
@@ -1,103 +1,101 @@
-.wrapper{
-    display:block;
-    margin-left:15px;
-  }
-  html {
-    scroll-behavior: smooth;
-  }
-  .sidenav { 
-    height:100%;
-    width:55px;
-    position: fixed;
-    z-index: 1;
-    top:0;
-    left: 0;
-    background-color:#111;
-    padding-top:60px;
-    overflow-wrap: break-word;
-  }
-  .document-header {
-    margin-left:55px;
-  }
-  
-  .sidenav-box {
-    color:#888;
-    width:100%;
-    border-top:1px solid #555;
-    padding-left: 3px;
-    padding-right:3px;
-    font-size:13px;
-    font-family: 'Courier New', Courier, monospace
-  }
-  
-  .sidenav-box:not(.sidenav-manually-disabled):not(.sidenav-disabled):hover {
-    background-color:#333;
-  }
-  
-  .sidenav-active {
-    color:white;
-  }
-  .sidenav-disabled {
-      background-color: #666;
-      color: #444;
-  }
-  .sidenav-manually-disabled {
-      background-color:#336;
-      color:white;
-  }
-  
-  .submit-button-panel {
-    margin-right: 10px;
-    margin-bottom: 10px;
-  }
+.wrapper {
+  display: block;
+  margin-left: 15px;
+}
+html {
+  scroll-behavior: smooth;
+}
+.sidenav {
+  height: 100%;
+  width: 55px;
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  background-color: #111;
+  padding-top: 60px;
+  overflow-wrap: break-word;
+}
+.document-header {
+  margin-left: 55px;
+}
 
-  .error-text {
-    text-align: end;
-    font-style: italic;
-    color: #8b0000;
-  }
-  
-  .submit-button {
-    margin-left: 5px;
-    border-width: 1px;
-    border-style:solid;
-    border-color:#ced5d9;
-  }
-  
-  .submit-button:hover {
-    background-color: #f3f3f3;
-    border-color:#000;
-  }
-  
-  .form-message-panel {
-    margin-left: 10px;
-    margin-bottom: 20px;
-  }
-  
-  .patient-info-panel {
-    color: white;
-  }
-  
-  .filled {
-      color:white;
-  
-  }
-  
-  .filter-filled { 
-      font-family: monospace;
-      margin:0;
-      padding:5px;
-  
-  }
-  
-  .floating-tools {
-      right:10px;
-      top:0;
-      width: 100px;
-      border-width: 0px 1px 1px 1px;
-      border-style: solid;
-      border-color:black;
-      position:fixed;
-      background-color:white;
-      z-index: 5;
-  }
+.sidenav-box {
+  color: #888;
+  width: 100%;
+  border-top: 1px solid #555;
+  padding-left: 3px;
+  padding-right: 3px;
+  font-size: 13px;
+  font-family: 'Courier New', Courier, monospace;
+}
+
+.sidenav-box:not(.sidenav-manually-disabled):not(.sidenav-disabled):hover {
+  background-color: #333;
+}
+
+.sidenav-active {
+  color: white;
+}
+.sidenav-disabled {
+  background-color: #666;
+  color: #444;
+}
+.sidenav-manually-disabled {
+  background-color: #336;
+  color: white;
+}
+
+.submit-button-panel {
+  margin-right: 10px;
+  margin-bottom: 10px;
+}
+
+.error-text {
+  text-align: end;
+  font-style: italic;
+  color: #8b0000;
+}
+
+.submit-button {
+  margin-left: 5px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #ced5d9;
+}
+
+.submit-button:hover {
+  background-color: #f3f3f3;
+  border-color: #000;
+}
+
+.form-message-panel {
+  margin-left: 10px;
+  margin-bottom: 20px;
+}
+
+.patient-info-panel {
+  color: white;
+}
+
+.filled {
+  color: white;
+}
+
+.filter-filled {
+  font-family: monospace;
+  margin: 0;
+  padding: 5px;
+}
+
+.floating-tools {
+  right: 10px;
+  top: 0;
+  width: 100px;
+  border-width: 0px 1px 1px 1px;
+  border-style: solid;
+  border-color: black;
+  position: fixed;
+  background-color: white;
+  z-index: 5;
+}

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -1646,7 +1646,11 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
           }
         };
         axios
-          .post('http://localhost:8090/etasu/met', specialtyRxBundle, options)
+          .post(
+            `${process.env.REACT_APP_REMS_ADMIN_SERVER_BASE}/etasu/met`,
+            specialtyRxBundle,
+            options
+          )
           .then(response => {
             const proceedToRems = () => {
               props.setSpecialtyRxBundle(specialtyRxBundle);

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -82,7 +82,6 @@ interface QuestionnaireProps {
   bundle?: Bundle;
   setPriorAuthClaim: (n: Bundle) => void;
   setSpecialtyRxBundle: (n: Bundle) => void;
-  setRemsAdminResponse: (n: any) => void;
   setFormElement: (n: HTMLElement) => void;
   tabIndex: number;
 }
@@ -1652,7 +1651,6 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
           .then(response => {
             const proceedToRems = () => {
               props.setSpecialtyRxBundle(specialtyRxBundle);
-              props.setRemsAdminResponse(response);
             };
             if (response.status == 201) {
               proceedToRems();

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -197,7 +197,8 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     if (props.reloadQuestionnaire) {
       repopulateAndReload();
     }
-  });
+  }, []);
+
   const loadAndMergeForms = (newResponse: QuestionnaireResponse | null) => {
     let lform = LForms.Util.convertFHIRQuestionnaireToLForms(
       props.questionnaireForm,

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -961,36 +961,30 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
         second: 'numeric'
       };
 
-      let count = 0;
+      const questionnaireResponses = partialResponses.entry
+        .map(bundleEntry => bundleEntry.resource)
+        .filter(resource => resource !== undefined);
 
-      partialResponses.entry.forEach(bundleEntry => {
-        let idMatch = false;
-        if (bundleEntry.resource?.contained) {
-          const questionnaireId = bundleEntry.resource?.contained[0].id;
-          idMatch = props.questionnaireForm.id === questionnaireId;
-        }
-        const questionnaireIdUrl = bundleEntry.resource?.questionnaire;
-
-        if (
+      const count = questionnaireResponses.reduce((sum, resource) => {
+        const idMatch = resource?.contained?.[0]?.id === props.questionnaireForm.id;
+        const questionnaireIdUrl = resource?.questionnaire;
+        const found =
           idMatch ||
           (questionnaireIdUrl &&
             props.questionnaireForm.id &&
-            questionnaireIdUrl.includes(props.questionnaireForm.id))
-        ) {
-          count = count + 1;
-          // add the option to the popupOptions
-          const date = new Date(bundleEntry?.resource?.authored || Date.now());
-          const option =
-            date.toLocaleDateString(undefined, options) +
-            ' (' +
-            bundleEntry?.resource?.status +
-            ')';
-          setPopupOptions([...popupOptions, option]);
-          if (bundleEntry.resource) {
-            partialForms[option] = bundleEntry.resource;
-          }
-        }
+            questionnaireIdUrl.includes(props.questionnaireForm.id));
+        return found ? sum + 1 : sum;
+      }, 0);
+
+      const newPopupOptions = questionnaireResponses.map(resource => {
+        const date = new Date(resource?.authored || Date.now());
+        const option = date.toLocaleDateString(undefined, options) + ' (' + resource?.status + ')';
+        partialForms[option] = resource as QuestionnaireResponse;
+        return option;
       });
+
+      setPopupOptions(newPopupOptions);
+
       console.log(popupOptions);
       console.log(partialForms);
 

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -120,7 +120,7 @@ type PopupState = {
   partialForms: Record<string, QuestionnaireResponse>;
   open: boolean;
   savedResponse: QuestionnaireResponse | null;
-  loadedForm: string;
+  formLoaded: string;
 };
 
 enum PopupActionType {
@@ -132,19 +132,17 @@ enum PopupActionType {
   CLOSE_POPUP,
   OPEN_POPUP,
   SAVE_RESPONSE,
-  SAVE_CURRENT_LOADED_FORM
+  SET_FORM_LOADED
 }
 
 type PopupAction =
   | { type: PopupActionType.LOAD; value: QuestionnaireResponse[] }
   | { type: PopupActionType.SAVE_RESPONSE; value: QuestionnaireResponse }
-  | { type: PopupActionType.SAVE_CURRENT_LOADED_FORM; value: string }
+  | { type: PopupActionType.SET_FORM_LOADED; value: string }
   | {
       type: Exclude<
         PopupActionType,
-        | PopupActionType.LOAD
-        | PopupActionType.SAVE_RESPONSE
-        | PopupActionType.SAVE_CURRENT_LOADED_FORM
+        PopupActionType.LOAD | PopupActionType.SAVE_RESPONSE | PopupActionType.SET_FORM_LOADED
       >;
     };
 
@@ -197,14 +195,15 @@ const reducer = (state: PopupState, action: PopupAction): PopupState => {
         finalOption: 'OK',
         options: []
       };
+    // these don't depend on the other pieces of state
     case PopupActionType.CLOSE_POPUP:
       return { ...state, open: false };
     case PopupActionType.OPEN_POPUP:
       return { ...state, open: true };
     case PopupActionType.SAVE_RESPONSE:
       return { ...state, savedResponse: action.value };
-    case PopupActionType.SAVE_CURRENT_LOADED_FORM:
-      return { ...state, loadedForm: action.value };
+    case PopupActionType.SET_FORM_LOADED:
+      return { ...state, formLoaded: action.value };
     default:
       return initialPopupState;
   }
@@ -217,7 +216,7 @@ const initialPopupState: PopupState = Object.freeze({
   partialForms: {},
   open: false,
   savedResponse: null,
-  loadedForm: 'New'
+  formLoaded: 'New'
 });
 
 export function QuestionnaireForm(props: QuestionnaireProps) {
@@ -846,7 +845,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
 
   const popupCallback = (returnValue: string) => {
     // display the form loaded
-    popupDispatch({ type: PopupActionType.SAVE_CURRENT_LOADED_FORM, value: returnValue });
+    popupDispatch({ type: PopupActionType.SET_FORM_LOADED, value: returnValue });
 
     if (popupState.partialForms[returnValue]) {
       // load the selected form
@@ -1794,7 +1793,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
           options={popupState.options}
           finalOption={popupState.finalOption}
           selectedCallback={popupCallback}
-          selectedValue={popupState.loadedForm}
+          selectedValue={popupState.formLoaded}
           open={popupState.open}
           close={() => popupDispatch({ type: PopupActionType.CLOSE_POPUP })}
         />
@@ -1822,7 +1821,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
         </div>
       )}
       <Stack flexDirection="column" spacing={1} p={1}>
-        {!isAdaptive && <Typography>Form Loaded: {popupState.loadedForm}</Typography>}
+        {!isAdaptive && <Typography>Form Loaded: {popupState.formLoaded}</Typography>}
         {getDisplayButtons()}
       </Stack>
     </div>

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -302,6 +302,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     }
     return firstResponse;
   };
+
   // handleGtable expands the items with contains a table level expression
   // the expression should be a list of objects
   // this function creates the controls based on the size of the expression
@@ -431,6 +432,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
 
     return newItemResponseList;
   };
+
   const getLibraryPrepopulationResult = (
     item: QuestionnaireItem,
     cqlResults: PrepopulationResults
@@ -477,6 +479,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     }
     return prepopulationResult;
   };
+
   const prepopulate = (
     items: QuestionnaireItem[],
     response_items: QuestionnaireResponseItem[],
@@ -595,6 +598,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       }
     });
   };
+
   const getDisplayCoding = (v: any, item: QuestionnaireItem) => {
     if (typeof v == 'string') {
       const answerValueSetReference = item.answerValueSet;
@@ -654,6 +658,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       display: displayText
     };
   };
+
   const populateMissingDisplay = (qItem: QuestionnaireItem) => {
     const codingList = qItem.answerOption;
     if (codingList) {
@@ -664,6 +669,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       });
     }
   };
+
   // Merge the items for the same linkId to comply with the LHCForm
   const mergeResponseForSameLinkId = (response: QuestionnaireResponse) => {
     const mergedResponse: QuestionnaireResponse = {
@@ -698,6 +704,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     }
     return mergedResponse;
   };
+
   const getRetrieveSaveQuestionnaireUrl = () => {
     // read configuration
     const updateDate = new Date();
@@ -706,6 +713,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       updateDate.toISOString().split('T')[0]
     }&status=in-progress`;
   };
+
   const loadPreviousForm = (showError = true) => {
     // search for any QuestionnaireResponses
     let questionnaireResponseUrl = getRetrieveSaveQuestionnaireUrl();
@@ -727,6 +735,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       )
       .catch(console.error);
   };
+
   const popupClear = (title: string, finalOption: string, logTitle: boolean) => {
     setPopupTitle(title);
     setPopupOptions([]);
@@ -735,6 +744,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       console.log(title);
     }
   };
+
   const popupLaunch = () => {
     setOpenPopup(true);
   };
@@ -862,6 +872,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     console.log('getPatient(): ' + requestType + ': ' + p);
     return p;
   };
+
   const getPractitioner = () => {
     let p = 'Unknown';
     let requestType = 'Unknown';
@@ -944,6 +955,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
         }
       });
   };
+
   const processSavedQuestionnaireResponses = (
     partialResponses: Bundle<QuestionnaireResponse>,
     displayErrorOnNoneFound: boolean
@@ -1003,6 +1015,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       popupLaunch();
     }
   };
+
   const isAdaptiveForm = () => {
     return (
       props.questionnaireForm.meta &&
@@ -1172,6 +1185,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       }
     }
   };
+
   const addAuthorToResponse = (qr: QuestionnaireResponse, practitionerRef: string) => {
     function traverseToItemsLeafNode(item: QuestionnaireResponseItem, practitionerRef: string) {
       if (!item.item) {
@@ -1279,6 +1293,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
     }
     return qr;
   };
+
   const isPriorAuthBundleValid = (bundle: Bundle) => {
     const resourceTypeList = ['Patient', 'Practitioner'];
 
@@ -1672,6 +1687,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       }
     }
   };
+
   const makeReference = (bundle: Bundle, resourceType: string) => {
     const entry = bundle.entry?.find(function (entry) {
       return entry.resource?.resourceType == resourceType;
@@ -1683,6 +1699,7 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       return resourceType + '/' + entry.resource?.id;
     }
   };
+
   const isAdaptive = isAdaptiveForm();
   const showPopup = !isAdaptive || isAdaptiveFormWithoutItem();
   return (

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -147,13 +147,18 @@ type PopupAction =
       >;
     };
 
+const getNewPopupOption = (questionnaireResponse: QuestionnaireResponse) => {
+  const date = new Date(questionnaireResponse?.authored || Date.now());
+  const option =
+    date.toLocaleDateString(undefined, DATE_TIME_FORMAT_OPTIONS) +
+    ' (' +
+    questionnaireResponse?.status +
+    ')';
+  return option;
+};
+
 const getNewPopupOptions = (questionnaireResponses: QuestionnaireResponse[]) => {
-  return questionnaireResponses.map(resource => {
-    const date = new Date(resource?.authored || Date.now());
-    const option =
-      date.toLocaleDateString(undefined, DATE_TIME_FORMAT_OPTIONS) + ' (' + resource?.status + ')';
-    return option;
-  });
+  return questionnaireResponses.map(getNewPopupOption);
 };
 
 const reducer = (state: PopupState, action: PopupAction): PopupState => {
@@ -1431,6 +1436,10 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
       const showPopup = !isAdaptiveForm() || isAdaptiveFormWithoutItem();
       storeQuestionnaireResponseToEhr(qr, showPopup);
       popupDispatch({ type: PopupActionType.SAVED_TO_EHR });
+
+      // After saving the form to the EHR, keep it loaded.
+      const popupOption = getNewPopupOption(qr as QuestionnaireResponse);
+      popupCallback(popupOption);
       if (showPopup) {
         popupDispatch({ type: PopupActionType.OPEN_POPUP });
       } else {

--- a/src/views/Questionnaire/QuestionnaireForm.tsx
+++ b/src/views/Questionnaire/QuestionnaireForm.tsx
@@ -80,7 +80,6 @@ interface QuestionnaireProps {
   updateReloadQuestionnaire: (n: boolean) => void;
   reloadQuestionnaire: boolean;
   bundle?: Bundle;
-  setPriorAuthClaim: (n: Bundle) => void;
   setSpecialtyRxBundle: (n: Bundle) => void;
   setFormElement: (n: HTMLElement) => void;
   tabIndex: number;
@@ -1639,7 +1638,6 @@ export function QuestionnaireForm(props: QuestionnaireProps) {
 
         console.log('specialtyRx', specialtyRxBundle);
 
-        props.setPriorAuthClaim(priorAuthBundle);
         const options = {
           headers: {
             Accept: 'application/json',

--- a/src/views/Questionnaire/SmartApp.tsx
+++ b/src/views/Questionnaire/SmartApp.tsx
@@ -638,38 +638,34 @@ export function SmartApp(props: SmartAppProps) {
   const renderButtons = (ref: Element) => {
     const element = (
       <div>
-        <div>
+        <div className="task-button">
+          <label>Only Show Unfilled Fields</label>{' '}
+          <input
+            type="checkbox"
+            onChange={() => {
+              filter(false);
+            }}
+            id={questionnaire ? `filterCheckbox-${questionnaire.id}` : 'filterCheckbox'}
+            ref={onFilterCheckboxRefChange}
+          ></input>
+        </div>
+        {showRequiredCheckbox && (
           <div className="task-button">
-            <label>Only Show Unfilled Fields</label>{' '}
+            <label>Ignore required fields</label>{' '}
             <input
               type="checkbox"
               onChange={() => {
-                filter(false);
+                updateRequired(false);
               }}
-              id={questionnaire ? `filterCheckbox-${questionnaire.id}` : 'filterCheckbox'}
-              ref={onFilterCheckboxRefChange}
+              id={
+                questionnaire
+                  ? `required-fields-checkbox-${questionnaire.id}`
+                  : 'required-fields-checkbox'
+              }
+              ref={onRequiredCheckboxRefChange}
             ></input>
           </div>
-          {showRequiredCheckbox ? (
-            <div className="task-button">
-              <label>Ignore required fields</label>{' '}
-              <input
-                type="checkbox"
-                onChange={() => {
-                  updateRequired(false);
-                }}
-                id={
-                  questionnaire
-                    ? `required-fields-checkbox-${questionnaire.id}`
-                    : 'required-fields-checkbox'
-                }
-                ref={onRequiredCheckboxRefChange}
-              ></input>
-            </div>
-          ) : (
-            <div />
-          )}
-        </div>
+        )}
       </div>
     );
     const root = createRoot(ref);

--- a/src/views/Questionnaire/SmartApp.tsx
+++ b/src/views/Questionnaire/SmartApp.tsx
@@ -685,53 +685,51 @@ export function SmartApp(props: SmartAppProps) {
     return isFetchingArtifacts ? (
       <div> Fetching resources ... </div>
     ) : (
-      <div>
-        <div className="App">
-          <div
-            className={'overlay ' + (showOverlay ? 'on' : 'off')}
-            onClick={() => {
-              console.log(showOverlay);
-              toggleOverlay();
-            }}
-          ></div>
-          {specialtyRxBundle && remsAdminResponse ? (
-            <RemsInterface
-              specialtyRxBundle={specialtyRxBundle}
-              remsAdminResponse={remsAdminResponse}
-            />
-          ) : (
-            <QuestionnaireForm
-              questionnaireForm={questionnaire}
-              appContext={appContext}
-              cqlPrepopulationResults={cqlPrepopulationResults}
-              request={orderResource}
-              bundle={bundle}
-              standalone={props.standalone}
-              response={response}
-              attested={attested}
-              setPriorAuthClaim={setPriorAuthClaim}
-              setSpecialtyRxBundle={setSpecialtyRxBundle}
-              setRemsAdminResponse={setRemsAdminResponse}
-              fhirVersion={FHIR_VERSION}
-              smartClient={smart}
-              renderButtons={renderButtons}
-              filterFieldsFn={filter}
-              filterChecked={filterChecked}
-              ignoreRequiredChecked={ignoreRequiredCheckbox}
-              formFilled={formFilled}
-              updateQuestionnaire={updateQuestionnaire}
-              ehrLaunch={ehrLaunch}
-              reloadQuestionnaire={reloadQuestionnaire}
-              updateReloadQuestionnaire={reload => setReloadQuestionnaire(reload)}
-              adFormCompleted={adFormCompleted}
-              updateAdFormCompleted={completed => setAdFormCompleted(completed)}
-              adFormResponseFromServer={adFormResponseFromServer}
-              updateAdFormResponseFromServer={response => setAdFormResponseFromServer(response)}
-              setFormElement={setFormElement}
-              tabIndex={props.tabIndex}
-            />
-          )}
-        </div>
+      <div className="App">
+        <div
+          className={'overlay ' + (showOverlay ? 'on' : 'off')}
+          onClick={() => {
+            console.log(showOverlay);
+            toggleOverlay();
+          }}
+        />
+        {specialtyRxBundle && remsAdminResponse ? (
+          <RemsInterface
+            specialtyRxBundle={specialtyRxBundle}
+            remsAdminResponse={remsAdminResponse}
+          />
+        ) : (
+          <QuestionnaireForm
+            questionnaireForm={questionnaire}
+            appContext={appContext}
+            cqlPrepopulationResults={cqlPrepopulationResults}
+            request={orderResource}
+            bundle={bundle}
+            standalone={props.standalone}
+            response={response}
+            attested={attested}
+            setPriorAuthClaim={setPriorAuthClaim}
+            setSpecialtyRxBundle={setSpecialtyRxBundle}
+            setRemsAdminResponse={setRemsAdminResponse}
+            fhirVersion={FHIR_VERSION}
+            smartClient={smart}
+            renderButtons={renderButtons}
+            filterFieldsFn={filter}
+            filterChecked={filterChecked}
+            ignoreRequiredChecked={ignoreRequiredCheckbox}
+            formFilled={formFilled}
+            updateQuestionnaire={updateQuestionnaire}
+            ehrLaunch={ehrLaunch}
+            reloadQuestionnaire={reloadQuestionnaire}
+            updateReloadQuestionnaire={reload => setReloadQuestionnaire(reload)}
+            adFormCompleted={adFormCompleted}
+            updateAdFormCompleted={completed => setAdFormCompleted(completed)}
+            adFormResponseFromServer={adFormResponseFromServer}
+            updateAdFormResponseFromServer={response => setAdFormResponseFromServer(response)}
+            setFormElement={setFormElement}
+            tabIndex={props.tabIndex}
+          />
+        )}
       </div>
     );
   } else if (props.standalone) {

--- a/src/views/Questionnaire/SmartApp.tsx
+++ b/src/views/Questionnaire/SmartApp.tsx
@@ -102,7 +102,6 @@ export function SmartApp(props: SmartAppProps) {
   const [showOverlay, setShowOverlay] = useState<boolean>(false);
   const appContext: AppContext | undefined = props.appContext;
   const [specialtyRxBundle, setSpecialtyRxBundle] = useState<Bundle | null>(null);
-  const [remsAdminResponse, setRemsAdminResponse] = useState<any | null>(null);
   const [orderResource, setOrderResource] = useState<OrderResource | undefined>();
   const [bundle, setBundle] = useState<Bundle>();
   const [priorAuthClaim, setPriorAuthClaim] = useState<Bundle>();
@@ -693,11 +692,8 @@ export function SmartApp(props: SmartAppProps) {
             toggleOverlay();
           }}
         />
-        {specialtyRxBundle && remsAdminResponse ? (
-          <RemsInterface
-            specialtyRxBundle={specialtyRxBundle}
-            remsAdminResponse={remsAdminResponse}
-          />
+        {specialtyRxBundle ? (
+          <RemsInterface specialtyRxBundle={specialtyRxBundle} />
         ) : (
           <QuestionnaireForm
             questionnaireForm={questionnaire}
@@ -710,7 +706,6 @@ export function SmartApp(props: SmartAppProps) {
             attested={attested}
             setPriorAuthClaim={setPriorAuthClaim}
             setSpecialtyRxBundle={setSpecialtyRxBundle}
-            setRemsAdminResponse={setRemsAdminResponse}
             fhirVersion={FHIR_VERSION}
             smartClient={smart}
             renderButtons={renderButtons}

--- a/src/views/Questionnaire/SmartApp.tsx
+++ b/src/views/Questionnaire/SmartApp.tsx
@@ -104,7 +104,6 @@ export function SmartApp(props: SmartAppProps) {
   const [specialtyRxBundle, setSpecialtyRxBundle] = useState<Bundle | null>(null);
   const [orderResource, setOrderResource] = useState<OrderResource | undefined>();
   const [bundle, setBundle] = useState<Bundle>();
-  const [priorAuthClaim, setPriorAuthClaim] = useState<Bundle>();
   const [filterChecked, setFilterChecked] = useState<boolean>(true);
   const [formFilled, setFormFilled] = useState<boolean>(false);
   const [reloadQuestionnaire, setReloadQuestionnaire] = useState<boolean>(false);
@@ -122,9 +121,6 @@ export function SmartApp(props: SmartAppProps) {
   useEffect(() => {
     if (!props.standalone) {
       ehrLaunch(false);
-    }
-    if (priorAuthClaim) {
-      console.log(priorAuthClaim); // TODO: I don't think we need this, it could be removed.
     }
   }, []);
   useEffect(() => {
@@ -700,7 +696,6 @@ export function SmartApp(props: SmartAppProps) {
             standalone={props.standalone}
             response={response}
             attested={attested}
-            setPriorAuthClaim={setPriorAuthClaim}
             setSpecialtyRxBundle={setSpecialtyRxBundle}
             fhirVersion={FHIR_VERSION}
             smartClient={smart}

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.css
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.css
@@ -4,14 +4,6 @@ body {
   font-family: sans-serif;
 }
 
-.left-form {
-  width: 46%;
-  display: inline-block;
-  margin-top: 25px;
-  margin-left: 25px;
-  padding: 5px;
-}
-
 .resource-entry {
   border-left: 4px solid #ffcccb;
   padding: 5px;

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.css
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.css
@@ -1,147 +1,139 @@
 body {
-    margin: 0;
-    padding: 0;
-    font-family: sans-serif;
-  }
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+}
 
-  .left-form { 
-    width: 46%;
-    display: inline-block;
-    margin-top: 25px;
-    margin-left: 25px;
-    padding: 5px;
-  }
+.left-form {
+  width: 46%;
+  display: inline-block;
+  margin-top: 25px;
+  margin-left: 25px;
+  padding: 5px;
+}
 
-  .right-form { 
-    width: 46%;
-    display:inline-block;
-    margin-top: 25px;
-    margin-left: 25px;
-    padding: 5px;
-  }
+.resource-entry {
+  border-left: 4px solid #ffcccb;
+  padding: 5px;
+  border-bottom: 1px solid grey;
+  background-color: #ededed;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
 
-  .resource-entry{
-    border-left: 4px solid #ffcccb;
-    padding: 5px;
-    border-bottom: 1px solid grey;
-    background-color: #ededed;
-    padding-top: 20px;
-    padding-bottom:20px;
-  }
+.resource-entry:hover {
+  border-left: 4px solid #ff6663;
+  background-color: #fdfdfd;
+}
 
-  .resource-entry:hover {
-      border-left: 4px solid #ff6663;
-      background-color: #fdfdfd;
-  }
+.resource-entry.active {
+  border-left: 4px solid #ff6663;
+  background-color: #f5f5f5;
+}
 
-  .resource-entry.active{
-    border-left: 4px solid #ff6663;
-    background-color: #f5f5f5;
-  }
-
-  .details{
-    margin-left: 30px;
-    background-color: #ededed;
-  }
+.details {
+  margin-left: 30px;
+  background-color: #ededed;
+}
 
 .submit-btn {
-    float: right;
-    margin-top: 6px;
-  }
-
-.submit-btn:hover{
-    border-width:1px 3px 1px 1px;
-    margin-left:2px;
-    margin-top:8px;
+  float: right;
+  margin-top: 6px;
 }
 
-.status-icon{
+.submit-btn:hover {
+  border-width: 1px 3px 1px 1px;
+  margin-left: 2px;
+  margin-top: 8px;
+}
+
+.status-icon {
   width: 100%;
-  height:5px;
+  height: 5px;
 }
 
-.bundle-entry{
+.bundle-entry {
   margin: 5px;
 }
 
-.renew-icon{
+.renew-icon {
   cursor: pointer;
   margin-left: 15px;
 }
 
-.refresh{
+.refresh {
   cursor: pointer;
   margin-left: 15px;
   animation-name: spin;
   animation-duration: 500ms;
   animation-iteration-count: 2;
-  animation-timing-function: ease-in-out; 
+  animation-timing-function: ease-in-out;
 }
 
-.requestBody{
+.requestBody {
   overflow-y: scroll;
-  height:500px;
+  height: 500px;
 }
 
-.jsonData{
-  line-height:16px;
+.jsonData {
+  line-height: 16px;
   font-family: 'Courier New', Courier, monospace;
   font-size: 14px;
 
   border-left: 2px solid #dddddd;
-  border-top:0px;
-  padding-left:6px;
+  border-top: 0px;
+  padding-left: 6px;
 
-  display:block;
+  display: block;
 }
 
-.elementBody{
-  color:#adadad;
+.elementBody {
+  color: #adadad;
 }
 
-.elementKey{
-  color:#343434
+.elementKey {
+  color: #343434;
 }
 
 @keyframes spin {
   from {
-      transform:rotate(0deg);
+    transform: rotate(0deg);
   }
   to {
-      transform:rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 
 /*  ETASU styling */
-.resource-entry-hover{
-  display:none;
-  padding-top:25px;
-  padding-left:25px;;
+.resource-entry-hover {
+  display: none;
+  padding-top: 25px;
+  padding-left: 25px;
 }
 
-.etasu-container{
-  padding-bottom:40px;
+.etasu-container {
+  padding-bottom: 40px;
   padding-left: 20px;
-  padding-right:20px;
+  padding-right: 20px;
 }
 
-.resource-entry-text{
+.resource-entry-text {
   font-weight: bold;
-  float:left;
-  width:75%;
+  float: left;
+  width: 75%;
 }
 
-.resource-entry:hover > .resource-entry-hover{
+.resource-entry:hover > .resource-entry-hover {
   clear: both;
   display: block !important;
 }
 
-.resource-entry-icon{
-  width:25%;
-  float:right;
-  text-align:right;
-} 
+.resource-entry-icon {
+  width: 25%;
+  float: right;
+  text-align: right;
+}
 
-.resource-child{
-  margin-left:35px;
+.resource-child {
+  margin-left: 35px;
 }

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
@@ -34,10 +34,10 @@ export default function RemsInterface(props: RemsInterfaceProps) {
   };
 
   const renderBundle = (bundle: Bundle) => {
-    return bundle.entry?.map(entry => {
+    return bundle.entry?.map((entry, index) => {
       const resource = entry.resource;
       if (resource) {
-        return <ResourceEntry resource={resource} />;
+        return <ResourceEntry resource={resource} key={`resource-${index}`} />;
       }
     });
   };

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
@@ -7,23 +7,7 @@ import { Bundle } from 'fhir/r4';
 import { Box } from '@mui/material';
 
 interface RemsInterfaceProps {
-  remsAdminResponse: RemsAdminResponse;
   specialtyRxBundle: Bundle;
-}
-interface RemsAdminResponse {
-  data: JsonData;
-}
-
-type MetRequirements = {
-  completed: boolean;
-  requirementName: string;
-  requirementDescription: string;
-};
-
-interface JsonData {
-  case_number: string;
-  status: string;
-  metRequirements: MetRequirements[];
 }
 
 export default function RemsInterface(props: RemsInterfaceProps) {

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
@@ -21,7 +21,7 @@ export default function RemsInterface(props: RemsInterfaceProps) {
     return bundle.entry?.map(entry => {
       const resource = entry.resource;
       if (resource) {
-        return <ResourceEntry resource={resource}></ResourceEntry>;
+        return <ResourceEntry resource={resource} />;
       }
     });
   };

--- a/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/RemsInterface.tsx
@@ -4,6 +4,7 @@ import './RemsInterface.css';
 import Paper from '@mui/material/Paper';
 import Button from '@mui/material/Button';
 import { Bundle } from 'fhir/r4';
+import { Box } from '@mui/material';
 
 interface RemsInterfaceProps {
   remsAdminResponse: RemsAdminResponse;
@@ -36,42 +37,30 @@ export default function RemsInterface(props: RemsInterfaceProps) {
     return bundle.entry?.map(entry => {
       const resource = entry.resource;
       if (resource) {
-        return (
-          <div>
-            <ResourceEntry resource={resource}></ResourceEntry>
-          </div>
-        );
+        return <ResourceEntry resource={resource}></ResourceEntry>;
       }
     });
   };
 
   return (
-    <div>
-      <div>
-        <div>
-          <div className="left-form">
-            <h1>Document Status</h1>
-            <Paper style={{ paddingBottom: '5px' }}>
-              <div className="status-icon" style={{ backgroundColor: '#5cb85c' }}></div>
-              <div className="bundle-entry">Status: Documents successfully submitted</div>
-              <div className="bundle-entry">
-                <Button variant="contained" onClick={toggleBundle}>
-                  View Bundle
-                </Button>
-              </div>
-            </Paper>
-            {viewBundle ? (
-              <div className="bundle-view">
-                <br></br>
-                <h3>Bundle</h3>
-                {renderBundle(props.specialtyRxBundle)}
-              </div>
-            ) : (
-              ''
-            )}
-          </div>
+    <Box sx={{ p: 5 }}>
+      <h1>Document Status</h1>
+      <Paper style={{ paddingBottom: '5px' }}>
+        <div className="status-icon" style={{ backgroundColor: '#5cb85c' }}></div>
+        <div className="bundle-entry">Status: Documents successfully submitted</div>
+        <div className="bundle-entry">
+          <Button variant="contained" onClick={toggleBundle}>
+            View Bundle
+          </Button>
         </div>
-      </div>
-    </div>
+      </Paper>
+      {viewBundle && (
+        <div className="bundle-view">
+          <br></br>
+          <h3>Bundle</h3>
+          {renderBundle(props.specialtyRxBundle)}
+        </div>
+      )}
+    </Box>
   );
 }

--- a/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
@@ -5,6 +5,7 @@ import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 
 interface ResourceEntryProps {
   resource: FhirResource;
+  key: string;
 }
 export default function ResourceEntry(props: ResourceEntryProps) {
   const [viewDetails, setViewDetails] = useState<boolean>(false);
@@ -16,7 +17,7 @@ export default function ResourceEntry(props: ResourceEntryProps) {
     setViewDetails(!viewDetails);
   };
   return (
-    <div>
+    <div key={props.key}>
       <div
         className={'resource-entry ' + [viewDetails ? 'active' : '']}
         onClick={toggleOpenDetails}

--- a/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
@@ -8,19 +8,22 @@ interface ResourceEntryProps {
 export default function ResourceEntry(props: ResourceEntryProps) {
   const [viewDetails, setViewDetails] = useState<boolean>(false);
 
-  const openDetails = () => {
+  const toggleOpenDetails = () => {
     setViewDetails(!viewDetails);
   };
   return (
     <div>
-      <div className={'resource-entry ' + [viewDetails ? 'active' : '']} onClick={openDetails}>
+      <div
+        className={'resource-entry ' + [viewDetails ? 'active' : '']}
+        onClick={toggleOpenDetails}
+      >
         <div>{props.resource['resourceType']}</div>
       </div>
-      {viewDetails ? (
+      {viewDetails && (
         <div className="details">
           <pre>{JSON.stringify(props.resource, null, '\t')}</pre>
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
+++ b/src/views/Questionnaire/components/RemsInterface/ResourceEntry.tsx
@@ -1,12 +1,16 @@
 import { useState } from 'react';
 import './RemsInterface.css';
 import { FhirResource } from 'fhir/r4';
+import { Box, Typography, useMediaQuery, useTheme } from '@mui/material';
 
 interface ResourceEntryProps {
   resource: FhirResource;
 }
 export default function ResourceEntry(props: ResourceEntryProps) {
   const [viewDetails, setViewDetails] = useState<boolean>(false);
+  const theme = useTheme();
+  const isXs = useMediaQuery(theme.breakpoints.down('sm'));
+  const space = isXs ? '  ' : '\t';
 
   const toggleOpenDetails = () => {
     setViewDetails(!viewDetails);
@@ -20,9 +24,11 @@ export default function ResourceEntry(props: ResourceEntryProps) {
         <div>{props.resource['resourceType']}</div>
       </div>
       {viewDetails && (
-        <div className="details">
-          <pre>{JSON.stringify(props.resource, null, '\t')}</pre>
-        </div>
+        <Box sx={{ whiteSpace: 'pre-wrap', wordWrap: 'break-word', p: 2 }} className="details">
+          <Typography component="p" fontFamily="Monospace" sx={{ fontSize: { xs: 10, sm: 14 } }}>
+            {JSON.stringify(props.resource, null, space)}
+          </Typography>
+        </Box>
       )}
     </div>
   );

--- a/src/views/Questionnaire/components/SelectPopup.tsx
+++ b/src/views/Questionnaire/components/SelectPopup.tsx
@@ -31,7 +31,7 @@ function SimpleDialog(props: SimpleDialogProps) {
           </ListItemButton>
         ))}
 
-        <ListItemButton autoFocus onClick={() => handleListItemClick('New')}>
+        <ListItemButton autoFocus onClick={handleClose}>
           <ListItemText primary={finalOption} />
         </ListItemButton>
       </List>
@@ -40,34 +40,27 @@ function SimpleDialog(props: SimpleDialogProps) {
 }
 
 interface SelectPopupProps {
+  selectedValue: string;
   selectedCallback: (n: string) => void;
   open: boolean;
+  close: () => void;
   title: string;
   options: string[];
   finalOption: string;
 }
 
 function SelectPopup(props: SelectPopupProps) {
-  const propOpen = props.open;
-  const selectedCallback = props.selectedCallback;
-  const { title, options, finalOption } = props;
-  const [open, setOpen] = useState<boolean>(false);
-  const [selectedValue, setSelectedValue] = useState<string>('');
-
-  useEffect(() => {
-    setOpen(propOpen);
-  }, [propOpen]);
+  const { title, options, finalOption, selectedCallback, selectedValue } = props;
 
   const handleClose = (value: string) => {
-    setOpen(false);
-    setSelectedValue(value);
+    props.close();
     selectedCallback(value);
   };
   return (
     <div>
       <SimpleDialog
         selectedValue={selectedValue}
-        open={open}
+        open={props.open}
         onClose={handleClose}
         title={title}
         options={options}

--- a/src/views/Questionnaire/components/SelectPopup.tsx
+++ b/src/views/Questionnaire/components/SelectPopup.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { List, ListItemButton, ListItemText, DialogTitle, Dialog } from '@mui/material';
 
 interface SimpleDialogProps {


### PR DESCRIPTION
## Describe your changes

> Please include a summary of the changes and the related issue/task. Please also include relevant motivation and context. List any dependencies that are required for this change, including links to other pull requests/branches in other repositories if applicable.

This PR implements WCAG techniques G146, G179, G199
* Liquid layout
* no loss of content or functionality when zooming in
* indication of form submission success (existing for submitting REMS bundle, but fixed bug with form loading)

It turns out LForms actually has built in display options for small, medium, and large screen sizes if one clicks the settings cog icon and selects an option from the View Mode dropdown. So that also already covers G146 and G179 on the QuestionnaireForm page.

[Default breakpoints in MUI 5](https://mui.com/material-ui/customization/breakpoints/#default-breakpoints) to reference for below

---

## Before - Home page with patient view and medication select dropdown
### xs screen  (problematic)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/5e97e7b7-85bd-4ec8-83ce-139d899cb2c5)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/8bc1c0f0-0e8b-4efd-92e0-cbb41fdb0bdb)

### sm screen (problematic at breakpoint, but otherwise OK)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/a6fc0755-2747-45c8-82f4-5ded894ad166)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/99006e8e-39f1-421d-a66f-f48de030a0d2)

### md screen (problematic horizontal scroll bar on patient view, but this is just above the sm-md breakpoint)
> present content without introducing horizontal scroll bars

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/a81283ca-7176-4f14-8574-7f988f008c41)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/6b699018-f703-4e5f-9c98-a512e1171b35)


### lg screen (OK)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/202ed564-d8f8-44c4-b715-6418ec624327)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/23db579b-3661-4bc3-8316-e8f5ade0464a)

## After - Home page 
### xs screen (after pre-wrapping whitespace, fixing ETASU/MedicationDispense.status text spacing, and text-wrapping MedicationRequest dropdown)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/5cc94377-2a66-4424-a0a5-20a96a52e424)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/901f9f0a-7985-457f-bc7d-afc01866ec2a)

### sm screen (after fixing ETASU/MedicationDispense.status text spacing)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/31befe90-f4f9-4e84-8302-0450a8c4c129)

### md screen (after pre-wrapping whitespace)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/65673ef4-518d-4cea-a724-1166c8908431)

---

## Before - Document Status
### Applies to all screen sizes xs, sm, md, lg - horizontal scrollbar for FHIR Resource JSON inside `<pre>` tag
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/17f5ac42-f4c3-4788-8e9b-6a3c31330a34)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/676783eb-4380-4d6a-9ecd-091b8938ddd9)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/370bb965-e180-45b1-bc39-14c9e0484e1a)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/386fb2fa-9430-4bcc-a32e-4839198f36e0)

## After - Document Status
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/e36b1489-9d64-4ca4-a12c-88ad95bdb134)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/7f8ef16c-81d8-468b-8026-8f421e45ec64)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/de7170be-4529-4c52-b1a4-dee6bbfa9092)

![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/cf37a811-7e83-48cb-a2e7-16973270dd5c)


---

## Before - QuestionnaireResponse form launched from within REMS SMART on FHIR app
### xs screen (problematic cut-off text with input fields' helper text and values)
![image](https://github.com/mcode/rems-smart-on-fhir/assets/33106214/552b8d54-698f-4511-9b3d-3038da8b7fd0)

## After - QuestionnaireResponse form 
### xs screen (no padding)
<img width="413" alt="image" src="https://github.com/mcode/rems-smart-on-fhir/assets/33106214/9bb1eff3-9011-4927-a73a-17bbb7101ced">
<img width="416" alt="image" src="https://github.com/mcode/rems-smart-on-fhir/assets/33106214/22a94431-be70-4b82-9a92-5fedd4fcd671">

### sm screen and above (original padding)
<img width="600" alt="image" src="https://github.com/mcode/rems-smart-on-fhir/assets/33106214/793f7c96-1697-4912-9e71-db854f9871c1">
<img width="600" alt="image" src="https://github.com/mcode/rems-smart-on-fhir/assets/33106214/25d87b09-960c-4052-8f92-d8ad42098ed2">


---


## Issue ticket number and Jira link

> Please include the Jira Ticket Number and Link for this issue/task.

https://jira.mitre.org/browse/REMS-654

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

